### PR TITLE
feat: add document to implement smart charts champion and adaptor layer

### DIFF
--- a/docs/SmartChart.md
+++ b/docs/SmartChart.md
@@ -1,0 +1,471 @@
+<!-- [AI] -->
+# SmartChart Integration Guide
+
+This document explains how the SmartChart component works, the prerequisites (data and functions) it requires, and the data types/objects exchanged between SmartChart and your app. It is based on the current codebase:
+
+- UI entry: `src/components/SmartChart.tsx` and `src/components/Chart.tsx`
+- App state and data flow: `src/store/*` (notably `ChartStore`, `ChartState`, `ChartAdapterStore`)
+- Data ingestion and streaming: `src/feed/*` and `src/binaryapi/*`
+- Public types: `src/types/*`
+- Example usage: `app/index.tsx`
+
+---
+
+## 1) High-level Architecture
+
+- `<SmartChart />` is a thin wrapper that initializes the MobX store context and renders `<Chart />` with your props.
+- `<Chart />` consumes props (see TChartProps) and initializes the main store, UI widgets, and the chart container. It passes your props into `ChartStore.init`.
+- `ChartStore` wires:
+  - BinaryAPI abstraction (wrapping your getQuotes/subscribeQuotes/unsubscribeQuotes)
+  - Feed (initial history + streaming, pagination)
+  - TradingTimes (market open/close, delayed feeds) using either provided chartData or feed flags
+  - Routing and UI settings
+- `ChartAdapterStore` is a bridge to the Flutter chart runtime (via `window.jsInterop`), forwarding all history/streaming updates and handling user interactions (scroll/zoom, crosshair, overlays).
+- The flow of data:
+  1) Props to SmartChart (TChartProps) → ChartStore
+  2) ChartStore creates BinaryAPI and Feed
+  3) Feed fetches initial data and emits stream updates
+  4) ChartAdapterStore forwards quotes to the Flutter chart view
+
+---
+
+## 2) Minimum Prerequisites
+
+You must supply data providers and essential props when embedding SmartChart:
+
+- unsubscribeQuotes: BinaryAPI['unsubscribeQuotes'] (REQUIRED)
+- getQuotes: TGetQuotes (RECOMMENDED for history and when endEpoch/static views are used)
+- subscribeQuotes: TSubscribeQuotes (RECOMMENDED for live streaming)
+- chartData.activeSymbols: ActiveSymbols (RECOMMENDED)
+- chartData.tradingTimes: Record<symbol, { isOpen, openTime, closeTime }> (RECOMMENDED)
+
+Notes:
+- The internal BinaryAPI wrapper in this repo expects only getQuotes/subscribeQuotes/unsubscribeQuotes. It does not fetch active symbols or trading times by itself here. Pass those via chartData (see example).
+- Without getQuotes/subscribeQuotes, SmartChart will render but not load real data.
+
+---
+
+## 3) Props API (TChartProps) Overview
+
+Essential data providers:
+- unsubscribeQuotes: BinaryAPI['unsubscribeQuotes']
+- getQuotes?: TGetQuotes
+- subscribeQuotes?: TSubscribeQuotes
+
+Data context:
+- symbol?: string
+- granularity?: TGranularity (0 for ticks; see types below)
+- chartType?: string (e.g., 'line', 'candles')
+
+Initial data:
+- chartData?: {
+    activeSymbols?: ActiveSymbols;
+    tradingTimes?: Record<string, { isOpen: boolean; openTime: string; closeTime: string }>;
+  }
+
+Lifecycle and behavior:
+- isLive?: boolean (enable live state styling)
+- startEpoch?: number
+- endEpoch?: number
+- isStaticChart?: boolean
+- anchorChartToLeft?: boolean
+- scrollToEpoch?: number | null
+- enableRouting?: boolean
+
+User settings/state:
+- settings?: TSettings
+- onSettingsChange?: (newSettings: Omit<TSettings, 'activeLanguages'>) => void
+- stateChangeListener?: TStateChangeListener
+- chartStatusListener?: (isChartReady: boolean) => boolean
+
+Layout/appearance:
+- isMobile?: boolean
+- enabledChartFooter?: boolean
+- enabledNavigationWidget?: boolean
+- yAxisMargin?: { top: number; bottom: number }
+- leftMargin?: number
+- crosshairState?: number | null
+- crosshairTooltipLeftAllow?: number | null
+- startWithDataFitMode?: boolean
+- isAnimationEnabled?: boolean
+
+Widgets (render props):
+- topWidgets?: () => React.ReactElement
+- bottomWidgets?: () => React.ReactElement
+- toolbarWidget?: () => React.ReactElement
+- chartControlsWidgets?: TChartControlsWidgets
+
+Other:
+- feedCall?: { activeSymbols?: boolean; tradingTimes?: boolean } (not typically needed if you pass chartData)
+- onMessage?: (message: TNotification) => void
+- networkStatus?: TNetworkConfig
+- clearChart?: () => void
+- shouldGetQuotes?: boolean
+- allowTickChartTypeOnly?: boolean
+- shouldFetchTradingTimes?: boolean
+- shouldDrawTicksFromContractInfo?: boolean
+- allTicks?: AuditDetailsForExpiredContract['all_ticks']
+- contractInfo?: ProposalOpenContract
+- maxTick?: number | null
+- zoom?: number
+- enableZoom?: boolean | null
+- enableScroll?: boolean | null
+- historical?: boolean
+- contracts_array?: any[] (see Contracts markers below)
+- children?: React.ReactNode (e.g., markers via FastMarker)
+
+See `src/types/props.types.ts` for the complete reference.
+
+---
+
+## 4) Data Provider Contracts
+
+### 4.1 TGetQuotes (History fetch)
+Signature:
+```
+type TGetQuotes = (params: {
+  symbol: string;
+  granularity: number;   // 0 for ticks, >0 for candles in seconds
+  count: number;
+  start?: number;
+  end?: number;
+  style?: string;        // 'ticks' or 'candles' (optional)
+}) => Promise<TGetQuotesResult>;
+```
+
+Return type (TGetQuotesResult):
+```
+type TGetQuotesResult = {
+  candles?: Array<{
+    open: number; high: number; low: number; close: number; epoch: number;
+  }>;
+  history?: {
+    prices: number[];
+    times: number[];   // epoch in seconds
+  };
+};
+```
+
+Behavior:
+- If granularity > 0, return candles.
+- If granularity = 0, return history (ticks). One of candles or history must be provided.
+
+### 4.2 TSubscribeQuotes (Live streaming)
+Signature:
+```
+type TSubscribeQuotes = (
+  params: { symbol: string; granularity: TGranularity },
+  callback: (quote: TQuote) => void
+) => () => void; // returns unsubscribe function
+```
+
+Callback TQuote:
+```
+type TQuote = {
+  Date: string;        // ISO-like, SmartChart will parse with 'Z' as UTC
+  Open?: number;
+  High?: number;
+  Low?: number;
+  Close: number;
+  tick?: TicksStreamResponse['tick']; // for ticks
+  ohlc?: OHLCStreamResponse['ohlc'];  // for candles
+  DT?: Date;
+  prevClose?: number;
+  Volume?: number;
+};
+```
+
+Notes:
+- For ticks: supply `tick` and `Close` with the spot quote; set `Date` using the epoch from the tick.
+- For candles: supply `ohlc` and OHLC/Close; set `Date` using `open_time` or equivalent.
+
+### 4.3 unsubscribeQuotes
+Signature:
+```
+type TUnsubscribeQuotes = (request?: TGetQuotesRequest, callback?: TResponseAPICallback) => void;
+```
+Used internally alongside subscription management. Implement to stop streaming on symbol/timeframe changes or component unmount.
+
+---
+
+## 5) Core Types in Use
+
+From `src/types/api-types.ts` and `src/types/props.types.ts`:
+
+- TGranularity = 0 | 60 | 120 | 180 | 300 | 600 | 900 | 1800 | 3600 | 7200 | 14400 | 28800 | 86400
+  - 0 → ticks (no aggregation). Any non-zero value is seconds per candle.
+
+- TGetQuotesRequest (used by BinaryAPI wrapper):
+```
+type TGetQuotesRequest = {
+  symbol: string;
+  ticks_history?: string;
+  adjust_start_time?: number;
+  count?: string | number;
+  end?: string;
+  granularity?: (see list above);
+  start?: string | number;
+  style?: 'candles' | 'ticks';
+  subscribe?: 0 | 1;
+};
+```
+
+- ActiveSymbols (required to populate market/symbol selection and decimals/pip sizes):
+```
+type ActiveSymbols = Array<{
+  display_name: string;
+  market: string;
+  market_display_name: string;
+  subgroup: string;
+  subgroup_display_name: string;
+  submarket: string;
+  submarket_display_name: string;
+  symbol: string;
+  symbol_type: string;
+  pip: number;
+  exchange_is_open: 0 | 1;
+  is_trading_suspended: 0 | 1;
+  delay_amount?: number;
+  // ...
+}>;
+```
+
+- TradingTimesResponse (if you fetch it yourself) is the raw form; in this repo we pass a simplified shape into `chartData`:
+```
+type TradingTimesMap = Record<string, { isOpen: boolean; openTime: string; closeTime: string }>;
+```
+
+- TSettings (user preferences that can be persisted):
+```
+type TSettings = {
+  countdown?: boolean;
+  historical?: boolean;
+  lang?: string;
+  language?: string;
+  minimumLeftBars?: number;
+  position?: string;
+  enabledNavigationWidget?: boolean;
+  isAutoScale?: boolean;
+  isHighestLowestMarkerEnabled?: boolean;
+  isSmoothChartEnabled?: boolean;
+  theme?: string;
+  activeLanguages?: Array<string | TLanguage> | null;
+  whitespace?: number;
+};
+```
+
+---
+
+## 6) Contracts/Markers (contracts_array)
+
+Use the `contracts_array` prop to send markers/overlays to the chart. These are forwarded to the Flutter chart via `ChartAdapterStore.updateContracts`.
+
+- Minimal marker item:
+```
+{
+  markers: Array<{
+    epoch: number;    // seconds
+    quote?: number;   // optional; SmartChart will interpolate if missing
+    // ... any additional fields consumed by your Flutter chart integration
+  }>;
+  // optional flags (e.g., isLive) depending on your Flutter chart
+}
+```
+
+Behavior:
+- If a marker lacks `quote`, SmartChart interpolates a price using the nearest ticks/candles before forwarding to the underlying chart.
+- The full structure is consumed by the Flutter chart config (`flutterChart.config.updateContracts`), so keep extra fields compatible with your Flutter side.
+
+---
+
+## 7) Lifecycle and Data Flow Details
+
+1) Mount:
+- SmartChart initializes the MobX store context.
+- Chart mounts, calls `ChartStore.init` with your props.
+- ChartStore:
+  - Creates `BinaryAPI` from your data providers.
+  - Prepares `TradingTimes` and builds a symbol map using `chartData.activeSymbols`.
+  - Initializes `Feed` and `ChartAdapterStore`.
+  - Kicks off the Flutter chart engine and then triggers `newChart()`.
+
+2) Initial fetch:
+- `Feed.fetchInitialData` builds a `TGetQuotesRequest` from `symbol/granularity/start/end`.
+- If `end` is set (historical/static), it fetches history only (no stream).
+- If live:
+  - For delayed markets, uses DelayedSubscription (with notifications).
+  - Otherwise uses RealtimeSubscription.
+- On resolution, Feed pushes quotes to ChartAdapterStore (`onTickHistory`) → Flutter chart renders.
+
+3) Streaming:
+- Subscription pushes new `TQuote` items to Feed → `ChartAdapterStore.onTick` → Flutter chart.
+- Connection events (close/reopen) are handled; on reopen the chart is refreshed.
+
+4) Pagination:
+- Flutter chart requests more history via `jsInterop.loadHistory` → `ChartAdapterStore.loadHistory` → `Feed.fetchPaginationData` → update.
+
+5) Symbol/timeframe changes:
+- `ChartState` detects changes (e.g., via Views/ChartMode UI) and calls `ChartStore.changeSymbol/newChart`, re-wiring feed and pushing the new series to the chart.
+
+---
+
+## 8) Events and Callbacks
+
+- chartStatusListener?: (isChartReady: boolean) => boolean
+  - Called when the chart core becomes ready. Return value is ignored by the chart; use it to trigger app-level side-effects.
+
+- stateChangeListener?: TStateChangeListener
+  - Called with granular state tags, e.g. interval change, market open/close, etc.
+
+- onCrosshairChange?: (state?: number) => void
+  - Receives crosshair state changes.
+
+- onSettingsChange?: (newSettings: Omit<TSettings, 'activeLanguages'>) => void
+  - Persist and/or react to user setting changes. Example: language or theme updates.
+
+- getIndicatorHeightRatio?: (chart_height: number, indicator_count: number) => { height: number; percent: number }
+  - Allows custom vertical allocation of bottom studies.
+
+---
+
+## 9) Quick Start Example
+
+Here is a condensed example inspired by `app/index.tsx`. It shows how to wire data providers and pass required props:
+
+```tsx
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import {
+  SmartChart,
+  ChartMode,
+  StudyLegend,
+  Views,
+  DrawTools,
+  Share,
+  ToolbarWidget,
+  ChartSetting,
+  ChartTitle,
+} from '@deriv-com/smartcharts';
+import { TQuote, TGranularity, TGetQuotesResult, ActiveSymbols } from 'src/types';
+
+// 1) Implement data providers:
+const subscribeQuotes = (
+  { symbol, granularity }: { symbol: string; granularity?: number },
+  callback: (quote: TQuote) => void
+) => {
+  // Subscribe to your WS and convert into TQuote in the callback.
+  // Return function to unsubscribe.
+  return () => {/* unsubscribe logic */};
+};
+
+const getQuotes = async ({
+  symbol,
+  granularity,
+  count,
+  start,
+  end,
+}: {
+  symbol: string;
+  granularity: number;
+  count: number;
+  start?: number;
+  end?: number;
+}): Promise<TGetQuotesResult> => {
+  // Fetch history via REST/WS, then convert to {candles} or {history}.
+  return { candles: [] };
+};
+
+const unsubscribeQuotes = (/* request?: TGetQuotesRequest */) => {
+  // Stop streaming by subscription id
+};
+
+// 2) Provide initial lists (ActiveSymbols + TradingTimes map):
+const chartData = {
+  activeSymbols: [] as ActiveSymbols,
+  tradingTimes: {} as Record<string, { isOpen: boolean; openTime: string; closeTime: string }>,
+};
+
+const App = () => {
+  const isMobile = /mobi/i.test(navigator.userAgent);
+  const [settings, setSettings] = React.useState({
+    language: 'en',
+    theme: 'dark',
+  });
+
+  return (
+    <SmartChart
+      id="chart-1"
+      symbol="R_100"
+      isMobile={isMobile}
+      settings={settings}
+      onSettingsChange={setSettings}
+      chartType="line"
+      granularity={0 as TGranularity}
+      getQuotes={getQuotes}
+      subscribeQuotes={subscribeQuotes}
+      unsubscribeQuotes={unsubscribeQuotes}
+      chartData={chartData}
+      topWidgets={() => <ChartTitle />}
+      toolbarWidget={() => (
+        <ToolbarWidget>
+          <ChartMode />
+          <StudyLegend />
+          <Views />
+          <DrawTools />
+          <Share />
+        </ToolbarWidget>
+      )}
+      chartControlsWidgets={() => <ChartSetting />}
+      enabledChartFooter
+      isLive
+    />
+  );
+};
+
+createRoot(document.getElementById('root')!).render(<App />);
+```
+
+---
+
+## 10) Implementation Notes and Best Practices
+
+- Always return a proper unsubscribe function from `subscribeQuotes`, and also implement `unsubscribeQuotes` to forget server-side subscriptions.
+- When emitting TQuote in live callbacks:
+  - For ticks, set `tick` and `Close` accordingly; set `Date` using the tick epoch.
+  - For candles, set `ohlc` and OHLC/Close; set `Date` using `open_time` or start of the candle.
+- Provide both `activeSymbols` and `tradingTimes` via `chartData`. SmartChart builds symbol maps, decimal places (pip), and open/close behavior from them.
+- Delayed markets: If `delay_amount` exists for a symbol, SmartChart will notify and route through a delayed subscription; quotes are still streamed but delayed.
+- Contracts/markers: Provide `epoch` per marker; omit `quote` to let SmartChart interpolate the Y position at that epoch. Keep any extra fields consistent with your Flutter chart handler.
+- Language/theme changes: If your app toggles settings, call `onSettingsChange` with a new TSettings; SmartChart will update theme and re-render accordingly.
+- Pagination: The chart will ask for older data when the user scrolls; SmartChart calls your providers automatically via Feed → BinaryAPI abstraction.
+
+---
+
+## 11) Where to Look in Code
+
+- SmartChart wrapper: `src/components/SmartChart.tsx`
+- Chart body and layout: `src/components/Chart.tsx`
+- Main store wiring: `src/store/index.ts` (MainStore) and `src/store/ChartStore.ts`
+- Chart state machine and prop propagation: `src/store/ChartState.ts`
+- Flutter chart adapter/interop: `src/store/ChartAdapterStore.ts`
+- Data ingestion: `src/feed/Feed.ts` and `src/binaryapi/BinaryAPI.ts`
+- Types: `src/types/props.types.ts` and `src/types/api-types.ts`
+- Full working sample: `app/index.tsx`
+
+---
+
+## 12) Troubleshooting
+
+- No data showing:
+  - Ensure `getQuotes` returns candles or history according to granularity.
+  - Ensure `subscribeQuotes` is invoked and invokes its callback with TQuote.
+  - Pass `chartData.activeSymbols` with correct `pip`/`symbol` fields.
+- Markers not visible:
+  - Check `contracts_array` markers contain `epoch` and that the epoch fits within the visible range.
+- Crosshair/scroll issues on mobile:
+  - See `ChartAdapterStore` logic for `isVerticalScrollEnabled`, scroll blocking, and touch handling.
+
+---
+
+This guide should be sufficient to integrate SmartChart with your own data transport and UI, using the public TChartProps and type contracts provided by the library.
+<!-- [/AI] -->

--- a/docs/adapter-design-smartcharts-champion.md
+++ b/docs/adapter-design-smartcharts-champion.md
@@ -1,0 +1,444 @@
+<!-- [AI] -->
+# Adapter Design: Client App ➜ @deriv-com/smartcharts-champion
+
+Objective
+- Keep existing data sources and WS transport in the client app unchanged.
+- Introduce a thin adapter that transforms existing requests/responses and reference data to the shape and function contracts required by smartcharts-champion as specified in docs/SmartChart.md.
+- Expose a stable adapter interface used only by the Chart page so the rest of the app remains untouched.
+
+What smartcharts-champion expects (from docs/SmartChart.md)
+- Functions:
+  - getQuotes(params): Promise<TGetQuotesResult>
+  - subscribeQuotes(params, callback): () => void  // MUST return an unsubscribe function
+  - unsubscribeQuotes(request?, callback?) => void  // optional; a convenience forget
+- Data passed via chartData:
+  - activeSymbols: ActiveSymbols
+  - tradingTimes: TradingTimesMap
+- Types (minimum set):
+  - TGranularity
+  - TGetQuotesRequest, TGetQuotesResult
+  - TQuote for streaming callbacks
+  - ActiveSymbols, TradingTimesMap
+
+--------------------------------------------------------------------------------
+
+Existing codebase: what we can reuse
+
+Transport (WebSocket + helpers)
+- chart_api.api (src/external/bot-skeleton/services/api/chart-api.js) provides:
+  - send(request): Promise<any>
+  - onMessage(): Observable<{ data: any }> | undefined
+  - forget(subscription_id: string): void
+  - forgetAll('ticks'): void (exists but should be avoided in favor of targeted forget by id)
+- Shaping:
+  - send is used for both one-shot and subscribe requests.
+  - onMessage streams ALL WS frames; we must filter by subscription.id to isolate the stream.
+
+Reference data (Active Symbols + Trading Times)
+- Active symbols enrichment pipeline (src/external/bot-skeleton/services/api/api-base.ts and active-symbols.js):
+  - ApiHelpers.instance.active_symbols.[active_symbols] holds the computed list ready for UI.
+  - Includes pip sizes and display names. Backward-compat guard: some places use underlying_symbol vs symbol.
+- Trading times (src/external/bot-skeleton/services/api/trading-times.js):
+  - trading_times structure contains is_opened and times (open/close).
+  - We must map to { isOpen, openTime, closeTime } per symbol.
+
+Chart page today (src/pages/chart/chart.tsx)
+- Currently wires @deriv-com/derivatives-charts with requestAPI/requestSubscribe/requestForget*.
+- We will replace the SmartChart provider props with adapter.getQuotes/subscribeQuotes/unsubscribeQuotes and pass chartData from adapter.
+
+--------------------------------------------------------------------------------
+
+Adapter high-level design
+
+Create a single module that binds the existing transport and services to champion contracts:
+
+- File: src/adapters/smartcharts-champion/index.ts
+- Public API:
+  - buildSmartchartsChampionAdapter(deps): SmartchartsChampionAdapter
+- Deps signature:
+  - transport: { send: (req: any) => Promise<any>; onMessage: () => { subscribe(cb): Subscription }; forget: (id: string) => void; }
+  - services: { getActiveSymbols(): Promise<ActiveSymbols> | ActiveSymbols; getTradingTimes(): Promise<any> | any; }
+- Returns:
+  - getQuotes(params): Promise<TGetQuotesResult>
+  - subscribeQuotes(params, onQuote): () => void
+  - unsubscribeQuotes?(request?, cb?)
+  - getChartData(): Promise<{ activeSymbols: ActiveSymbols; tradingTimes: TradingTimesMap }>
+
+--------------------------------------------------------------------------------
+
+Interfaces required for the transformation
+
+Types (ts interfaces for adapter boundaries)
+- src/types/smartchart.types.ts (new)
+  - TGranularity
+  - TGetQuotesRequest
+  - TGetQuotesResult
+  - TQuote
+  - ActiveSymbol, ActiveSymbols
+  - TradingTimesMap
+
+Minimal definitions:
+```ts
+// [AI] src/types/smartchart.types.ts (summary, see migration doc for full)
+export type TGranularity = 0 | 60 | 120 | 180 | 300 | 600 | 900 | 1800 | 3600 | 7200 | 14400 | 28800 | 86400;
+
+export type TGetQuotesRequest = {
+  symbol: string;
+  granularity: TGranularity;
+  count: number;
+  start?: number;
+  end?: number;
+  style?: 'candles' | 'ticks';
+};
+
+export type TGetQuotesResult = {
+  candles?: Array<{ open: number; high: number; low: number; close: number; epoch: number }>;
+  history?: { prices: number[]; times: number[] };
+};
+
+export type TQuote = {
+  Date: string;
+  Close: number;
+  Open?: number;
+  High?: number;
+  Low?: number;
+  Volume?: number;
+  tick?: { epoch: number; quote: number; symbol?: string; id?: string };
+  ohlc?: { open: number; high: number; low: number; close: number; open_time: number };
+  DT?: Date;
+  prevClose?: number;
+};
+
+export type ActiveSymbol = {
+  display_name: string;
+  market: string;
+  market_display_name: string;
+  subgroup: string;
+  subgroup_display_name: string;
+  submarket: string;
+  submarket_display_name: string;
+  symbol: string;
+  symbol_type: string;
+  pip: number;
+  exchange_is_open: 0 | 1;
+  is_trading_suspended: 0 | 1;
+  delay_amount?: number;
+};
+export type ActiveSymbols = ActiveSymbol[];
+
+export type TradingTimesMap = Record<string, { isOpen: boolean; openTime: string; closeTime: string }>;
+// [/AI]
+```
+
+Adapter interfaces:
+```ts
+// [AI] Suggested adapter surface (src/adapters/smartcharts-champion/types.ts)
+import { TGranularity, TGetQuotesRequest, TGetQuotesResult, TQuote, ActiveSymbols, TradingTimesMap } from '@/types/smartchart.types';
+
+export type TTransport = {
+  send: (req: any) => Promise<any>;
+  onMessage: () => { subscribe: (cb: (payload: { data: any }) => void) => { unsubscribe?: () => void } };
+  forget: (id: string) => void;
+};
+
+export type TServices = {
+  getActiveSymbols: () => Promise<ActiveSymbols> | ActiveSymbols;
+  getTradingTimes: () => Promise<any> | any; // source internal type, we will map to TradingTimesMap
+};
+
+export type SmartchartsChampionAdapter = {
+  getQuotes: (params: TGetQuotesRequest) => Promise<TGetQuotesResult>;
+  subscribeQuotes: (params: { symbol: string; granularity: TGranularity }, onQuote: (q: TQuote) => void) => () => void;
+  unsubscribeQuotes?: (request?: TGetQuotesRequest, cb?: (resp: any) => void) => void;
+  getChartData: () => Promise<{ activeSymbols: ActiveSymbols; tradingTimes: TradingTimesMap }>;
+};
+// [/AI]
+```
+
+--------------------------------------------------------------------------------
+
+Transformations (exact mapping rules)
+
+1) One-shot history → TGetQuotesResult
+- Input: Deriv WS ticks_history (for ticks or candles)
+- If granularity = 0:
+  - Request: { ticks_history: symbol, end: 'latest' or end, adjust_start_time: 1, count: String(count), ...(start?) }
+  - Response: resp.history: { prices: number[], times: number[] }
+  - Output: { history: { prices, times } }
+- If granularity > 0:
+  - Request: { ticks_history: symbol, style: 'candles', granularity, count, end, adjust_start_time: 1, ...(start?) }
+  - Response: resp.candles: Array<{ open, high, low, close, epoch|open_time }>
+  - Output: { candles: map each to { open, high, low, close, epoch } } (epoch := c.epoch || c.open_time as number)
+
+2) Streaming → TQuote
+- First response to subscribe request often contains subscription.id and a data payload (tick or ohlc).
+- Ticks (granularity = 0):
+  - Input: msg.msg_type === 'tick' and msg.tick: { epoch, quote, symbol, id? }, subscription.id present
+  - Output TQuote: { Date: String(epoch), Close: Number(quote), tick: msg.tick }
+- Candles (granularity > 0):
+  - Input: msg.msg_type === 'ohlc' and msg.ohlc: { open, high, low, close, open_time }, subscription.id present
+  - Output TQuote: { Date: String(open_time), Open: Number(open), High: Number(high), Low: Number(low), Close: Number(close), ohlc: msg.ohlc }
+- Isolation: Only forward messages where data.subscription.id === currentId to onQuote.
+
+3) ActiveSymbols → ActiveSymbols (champion)
+- Source: ApiHelpers.instance.active_symbols.active_symbols (already enriched)
+- Ensure each object includes fields used by UI and pip size. If only symbol exists (no underlying_symbol), keep symbol. If both exist in app, prefer symbol for champion.
+- Champion list can be passed as-is if it already matches fields defined above; otherwise map keys to match.
+
+4) Trading Times → TradingTimesMap
+- Source: trading-times.js structure per symbol:
+  - { is_opened, times: { open_time, close_time }, is_open_all_day?, is_closed_all_day? ... }
+- Output per symbol:
+  - { isOpen: Boolean(is_opened), openTime: String(times.open_time), closeTime: String(times.close_time) }
+
+--------------------------------------------------------------------------------
+
+Adapter Implementation Outline
+
+File: src/adapters/smartcharts-champion/index.ts
+```ts
+// [AI]
+import type { SmartchartsChampionAdapter, TTransport, TServices } from './types';
+import type { TGranularity, TGetQuotesRequest, TGetQuotesResult, TQuote, TradingTimesMap } from '@/types/smartchart.types';
+
+const toTGetQuotesResult = (resp: any, granularity: TGranularity): TGetQuotesResult => {
+  const is_ticks = !granularity || granularity === 0;
+  if (is_ticks) {
+    const history = resp?.history || resp?.ticks_history || {};
+    return { history: { prices: history.prices || [], times: history.times || [] } };
+  }
+  const candles = (resp?.candles || []).map((c: any) => ({
+    open: Number(c.open),
+    high: Number(c.high),
+    low: Number(c.low),
+    close: Number(c.close),
+    epoch: Number(c.epoch || c.open_time),
+  }));
+  return { candles };
+};
+
+const toTQuoteFromStream = (msg: any, granularity: TGranularity): TQuote | null => {
+  const is_ticks = !granularity || granularity === 0;
+  if (is_ticks && msg?.tick) {
+    const { epoch, quote } = msg.tick;
+    return { Date: String(epoch), Close: Number(quote), tick: msg.tick };
+  }
+  if (!is_ticks && msg?.ohlc) {
+    const { open, high, low, close, open_time } = msg.ohlc;
+    return {
+      Date: String(open_time),
+      Open: Number(open),
+      High: Number(high),
+      Low: Number(low),
+      Close: Number(close),
+      ohlc: msg.ohlc,
+    };
+  }
+  return null;
+};
+
+const toTradingTimesMap = (src: any): TradingTimesMap => {
+  const map: TradingTimesMap = {};
+  if (!src) return map;
+  Object.keys(src).forEach(symbol => {
+    const info = src[symbol];
+    map[symbol] = {
+      isOpen: !!info?.is_opened,
+      openTime: String(info?.times?.open_time || ''),
+      closeTime: String(info?.times?.close_time || ''),
+    };
+  });
+  return map;
+};
+
+export const buildSmartchartsChampionAdapter = (transport: TTransport, services: TServices): SmartchartsChampionAdapter => {
+  const getQuotes = async ({ symbol, granularity, count, start, end }: TGetQuotesRequest): Promise<TGetQuotesResult> => {
+    const is_ticks = !granularity || granularity === 0;
+    const req: any = {
+      ticks_history: symbol,
+      end: end ? String(end) : 'latest',
+      adjust_start_time: 1,
+      ...(start ? { start: String(start) } : {}),
+      ...(is_ticks ? { style: 'ticks', count: String(count) } : { style: 'candles', granularity, count: String(count) }),
+    };
+    const resp = await transport.send(req);
+    return toTGetQuotesResult(resp, granularity);
+  };
+
+  const subscribeQuotes = (
+    { symbol, granularity }: { symbol: string; granularity: TGranularity },
+    onQuote: (q: TQuote) => void
+  ) => {
+    const is_ticks = !granularity || granularity === 0;
+    const req: any = is_ticks ? { ticks: symbol, subscribe: 1 } : { ticks_history: symbol, style: 'candles', granularity, subscribe: 1 };
+    let currentId: string | null = null;
+    let rxSub: { unsubscribe?: () => void } | undefined;
+
+    transport.send(req).then((first: any) => {
+      currentId = first?.subscription?.id || null;
+      const firstQuote = toTQuoteFromStream(first, granularity);
+      if (firstQuote) onQuote(firstQuote);
+
+      rxSub = transport.onMessage()?.subscribe(({ data }: { data: any }) => {
+        if (data?.subscription?.id === currentId) {
+          const q = toTQuoteFromStream(data, granularity);
+          if (q) onQuote(q);
+        }
+      });
+    });
+
+    return () => {
+      rxSub?.unsubscribe?.();
+      if (currentId) transport.forget(currentId);
+    };
+  };
+
+  const unsubscribeQuotes = (_req?: TGetQuotesRequest) => {
+    // Optional convenience: if you keep a request->id map, forget by id here.
+    // Default approach: rely on the unsubscribe function returned by subscribeQuotes.
+  };
+
+  const getChartData = async () => {
+    const activeSymbols = await services.getActiveSymbols();
+    const rawTradingTimes = await services.getTradingTimes();
+    const tradingTimes = toTradingTimesMap(rawTradingTimes);
+    return { activeSymbols, tradingTimes };
+  };
+
+  return { getQuotes, subscribeQuotes, unsubscribeQuotes, getChartData };
+};
+// [/AI]
+```
+
+--------------------------------------------------------------------------------
+
+Wiring the adapter in the Chart page
+
+Replace @deriv-com/derivatives-charts with @deriv-com/smartcharts-champion and use the adapter’s functions.
+
+- Create a builder for services:
+  - getActiveSymbols: use ApiHelpers.instance.active_symbols.active_symbols (array)
+  - getTradingTimes: read from your trading-times service or cache (src/external/bot-skeleton/services/api/trading-times.js)
+
+- Build the adapter once (React useMemo) and pass functions to SmartChart.
+
+Example integration:
+```tsx
+// [AI] src/pages/chart/chart.tsx (highlights)
+import { SmartChart, ChartTitle, ToolbarWidget, ChartMode, StudyLegend, Views, DrawTools, Share } from '@deriv-com/smartcharts-champion';
+import '@deriv-com/smartcharts-champion/dist/smartcharts.css';
+import chart_api from '@/external/bot-skeleton/services/api/chart-api';
+import { ApiHelpers } from '@/external/bot-skeleton';
+import { buildSmartchartsChampionAdapter } from '@/adapters/smartcharts-champion';
+import type { ActiveSymbols } from '@/types/smartchart.types';
+
+const adapter = buildSmartchartsChampionAdapter(
+  {
+    send: (req: any) => chart_api.api.send(req),
+    onMessage: () => chart_api.api.onMessage(),
+    forget: (id: string) => chart_api.api.forget(id),
+  },
+  {
+    getActiveSymbols: () => {
+      const maybe = (ApiHelpers?.instance?.active_symbols as any);
+      const list: ActiveSymbols =
+        maybe?.active_symbols ?? // api-helpers.js style
+        maybe ?? [];             // already an array
+      return list;
+    },
+    getTradingTimes: () => {
+      // Hook into your trading-times service/cache (ensure the raw structure has is_opened and times fields)
+      // e.g., trading_times_service.trading_times
+      return window.__trading_times_cache__ || {};
+    },
+  }
+);
+
+const Chart = observer(() => {
+  // ... stores, settings, symbol, chart_type, granularity, etc.
+  const [chartData, setChartData] = React.useState({ activeSymbols: [], tradingTimes: {} });
+
+  React.useEffect(() => {
+    adapter.getChartData().then(setChartData);
+  }, []);
+
+  return (
+    <SmartChart
+      id="dbot"
+      symbol={symbol}
+      chartType={chart_type}
+      granularity={granularity}
+      isMobile={isMobile}
+      settings={settings}
+      getQuotes={adapter.getQuotes}
+      subscribeQuotes={adapter.subscribeQuotes}
+      unsubscribeQuotes={adapter.unsubscribeQuotes}
+      chartData={chartData}
+      topWidgets={() => <ChartTitle onChange={onSymbolChange} />}
+      toolbarWidget={() => (
+        <ToolbarWidget>
+          <ChartMode />
+          <StudyLegend />
+          <Views />
+          <DrawTools />
+          <Share />
+        </ToolbarWidget>
+      )}
+      enabledNavigationWidget={isDesktop}
+      enabledChartFooter={false}
+      isLive
+      leftMargin={80}
+    />
+  );
+});
+// [/AI]
+```
+
+--------------------------------------------------------------------------------
+
+Edge cases and behavior alignment
+
+- Market closed:
+  - Current code sometimes returns an empty array on 'MarketIsClosed'. For champion, preserve the behavior by not emitting quotes; chart will show no updates. getQuotes should still return the last available history.
+- Delayed markets (delay_amount):
+  - Include delay_amount in ActiveSymbols so SmartChart can handle delayed subscription UX if it supports it. No special handling needed in adapter.
+- Re-subscription on symbol/granularity change:
+  - Champion will call subscribeQuotes again; ensure unsubscribe function from the previous call is executed in the page logic or by SmartChart. The adapter already returns a proper unsubscribe closure.
+- Pagination:
+  - Champion may use jsInterop.loadHistory; you don’t need to expose anything extra—getQuotes supports start/end and count. Ensure your getQuotes handles past ranges by setting end to the requested epoch and omitting count accordingly.
+- Connection state:
+  - The adapter relies on transport; reconnection is handled at the transport layer (chart_api.api.init/reconnect). No extra work needed in adapter.
+
+--------------------------------------------------------------------------------
+
+Validation checklist
+
+- Functions:
+  - getQuotes returns candles/history aligned with granularity.
+  - subscribeQuotes emits only subscription-specific messages and returns an unsubscribe that calls forget(id) and unsubscribes Rx.
+  - unsubscribeQuotes is available (even as a passthrough), not required if you rely on the returned unsubscribe.
+- chartData:
+  - activeSymbols populated and includes pip, display_name, symbol fields.
+  - tradingTimes mapped to { isOpen, openTime, closeTime } per symbol string.
+- UI:
+  - Symbol changes and interval changes rewire correctly with no ghost updates.
+  - CSS/assets loaded from @deriv-com/smartcharts-champion.
+- No dangling subscriptions after unmount/navigation.
+
+--------------------------------------------------------------------------------
+
+Implementation tasks (concise)
+
+- Add src/types/smartchart.types.ts (as per types above).
+- Add src/adapters/smartcharts-champion/types.ts and index.ts with the adapter implementation.
+- Update src/pages/chart/chart.tsx:
+  - Swap package to @deriv-com/smartcharts-champion and CSS path.
+  - Replace previous requestAPI/requestSubscribe/requestForget* with adapter’s getQuotes/subscribeQuotes/unsubscribeQuotes.
+  - Fetch chartData via adapter.getChartData(), pass to SmartChart.
+- Ensure services:
+  - Expose a way to retrieve the current active symbols array and trading times map (or cache).
+- Remove legacy forgetAll('ticks') in component cleanup if redundant.
+- Keep subscription isolation and proper cleanup in the adapter.
+
+This adapter approach lets the app keep its existing WS and services, while presenting the exact functions and data contracts required by smartcharts-champion. It centralizes transformations, reduces risk during migration, and keeps the rest of the app stable.
+<!-- [/AI] -->

--- a/docs/derivative-chart.md
+++ b/docs/derivative-chart.md
@@ -1,0 +1,480 @@
+<!-- [AI] -->
+# SmartChart: Workflow, Lifecycle, Required Props, Functions, and Data Contracts
+
+This document provides a detailed, workflow-first reference for integrating SmartChart into your application. It focuses on:
+- End-to-end workflow and lifecycle (mount → data load → updates → unmount)
+- Required props and function contracts (with types)
+- Exact request/response object shapes and streaming model
+- Practical integration sequence and examples
+
+Key sources:
+- src/components/SmartChart.tsx
+- src/components/Chart.tsx
+- src/types/props.types.ts
+- src/binaryapi/BinaryAPI.ts
+
+--------------------------------------------------------------------------------
+
+## 1) High-level Workflow
+
+SmartChart does not fetch data by itself. Your app provides network functions and data; SmartChart orchestrates requests using those functions.
+
+Top-level flow:
+1) Initialization
+   - SmartChart initializes a MobX store context (initContext) once, then renders Chart within Provider.
+   - Chart mounts the chart adapter, prepares UI, and pushes initial props to the store.
+
+2) Data provisioning
+   - You must provide network functions for one-shot requests and streaming.
+   - SmartChart will use these to retrieve:
+     - Active Symbols
+     - Trading Times
+     - Tick/Candle History (one-shot and/or streaming)
+   - You may preload some data via initialData/chartData props to reduce API calls.
+
+3) User interactions/prop changes
+   - Changing symbol, granularity, or chart type triggers history reloads and (re)subscriptions.
+   - Crosshair, controls, widgets, and dialogs update via store.
+
+4) Unsubscribe/cleanup
+   - On unmount, SmartChart tears down adapters, cancels streams (via your forget functions), and cleans internal state.
+
+--------------------------------------------------------------------------------
+
+## 2) Lifecycle Timeline
+
+From src/components/SmartChart.tsx and src/components/Chart.tsx
+
+- SmartChart.tsx
+  - Creates context (initContext) at first render
+  - Provides store via React Context Provider
+  - Renders Chart with all props you pass
+
+- Chart.tsx (observer):
+  - On first mount:
+    - initGA(); logPageView();
+    - updateProps(props) → put latest props into store
+    - init(rootEl, props) → initializes internal chart state
+    - chartAdapter.onMount(chartContainerEl) → connect DOM to renderer
+  - On every render:
+    - updateProps(props) → props changes are propagated to store
+  - On unmount:
+    - destroy() → cleans store, forgets streams, disposes resources
+    - chartAdapter.onUnmount()
+
+Additional lifecycle behaviors:
+- Mobile: crosshair forced visible (state=2) to show price info
+- Contracts markers updated when contracts_array changes
+- UI dialogs and widgets mounted, with a dedicated modal portal (#smartcharts_modal)
+
+--------------------------------------------------------------------------------
+
+## 3) Required Functions and Data Contracts
+
+These functions are required. SmartChart calls them; you implement how they talk to your backend (e.g., Deriv WebSocket API).
+
+Type aliases (from src/types/props.types.ts):
+- TBinaryAPIRequest: generic request object
+- TBinaryAPIResponse: generic response envelope
+- TResponseAPICallback: (response: TBinaryAPIResponse) => void
+
+Function contracts:
+- requestAPI: (request: TBinaryAPIRequest) => Promise<TBinaryAPIResponse>
+  - One-shot calls (e.g., active_symbols, trading_times, time, ticks_history without subscribe)
+
+- requestSubscribe: (request: TBinaryAPIRequest, callback: TResponseAPICallback) => void
+  - Start a stream and call callback(response) for each update
+  - Keep association of request ↔ callback to allow requestForget
+
+- requestForget: (request: TBinaryAPIRequest, callback: TResponseAPICallback) => void
+  - Stop the stream that was begun with requestSubscribe using the same pair
+
+- requestForgetStream?: (id: string) => void
+  - Optional. If you manage subscription ids (e.g., from response.subscription.id), you can forget by id
+
+Generic envelopes:
+- TBinaryAPIRequest
+  - passthrough?: Record<string, unknown>
+  - req_id?: number
+  - [key: string]: unknown
+- TBinaryAPIResponse
+  - echo_req: Record<string, unknown>
+  - req_id?: number
+  - msg_type: string
+  - [key: string]: unknown
+
+Practical notes:
+- SmartChart forwards request objects as-is (no internal fetch). You must recognize these request shapes.
+- For streaming, your transport should deliver responses to the provided callback continuously.
+- Prefer requestForgetStream if you have subscription ids; otherwise rely on requestForget with the original request+callback.
+
+--------------------------------------------------------------------------------
+
+## 4) Request/Response Shapes and Streaming Model
+
+SmartChart (often via BinaryAPI helper) uses Deriv-like payloads for ticks history.
+
+Ticks History (one-shot):
+- Ticks (granularity 0 or undefined):
+```json
+{
+  "ticks_history": "SYMBOL",
+  "style": "ticks",
+  "end": "latest",
+  "count": 1000,
+  "adjust_start_time": 1
+}
+```
+
+- Candles (granularity > 0):
+```json
+{
+  "ticks_history": "SYMBOL",
+  "style": "candles",
+  "granularity": 60,
+  "end": "latest",
+  "count": 1000,
+  "adjust_start_time": 1
+}
+```
+
+Streaming variant:
+- Add `"subscribe": 1` to the above. You should then call the callback for each incoming tick/candle:
+```json
+{
+  "msg_type": "tick",
+  "tick": {
+    "symbol": "SYMBOL",
+    "epoch": 1725700000,
+    "quote": 123.45,
+    "id": "sub-123"
+  },
+  "subscription": { "id": "sub-123" }
+}
+```
+
+Request building logic reference:
+- src/binaryapi/BinaryAPI.ts (createTickHistoryRequest)
+  - style = 'ticks' if granularity falsy, otherwise 'candles'
+  - default count = 1000 unless start is set (then omit count)
+  - end default 'latest'
+  - optional start/end/subscribe/adjust_start_time
+
+Other one-shot requests SmartChart may make via your requestAPI:
+- Active Symbols:
+```json
+{ "active_symbols": "brief" }
+```
+- Trading Times:
+```json
+{ "trading_times": "today" }
+```
+- Server Time:
+```json
+{ "time": 1 }
+```
+
+Unsubscribe
+- By request pair:
+  - requestForget(request, callback)
+- By subscription id (optional):
+  - requestForgetStream("sub-123")
+
+--------------------------------------------------------------------------------
+
+## 5) Props Catalog (Types and Behavior)
+
+Full type: TChartProps (see src/types/props.types.ts). Summary by category:
+
+Required network functions:
+- requestAPI: BinaryAPI['requestAPI']
+- requestSubscribe: BinaryAPI['requestSubscribe']
+- requestForget: BinaryAPI['requestForget']
+- requestForgetStream?: BinaryAPI['requestForgetStream']
+
+Core identification & data:
+- id?: string
+  - Unique chart identifier for layout persistence; if omitted, no persistence
+- symbol?: string
+- granularity?: TGranularity (0 = ticks, >0 = candle size in seconds)
+- chartType?: string (see ChartTypes in src/Constant.tsx)
+- feedCall?: { activeSymbols?: boolean; tradingTimes?: boolean }
+  - Hint for what SmartChart may request
+
+Settings & behavior:
+- settings?: TSettings
+  - { countdown?, historical?, lang?, language?, minimumLeftBars?, position?, enabledNavigationWidget?, isAutoScale?, isHighestLowestMarkerEnabled?, theme?, activeLanguages?, whitespace? }
+- onSettingsChange?: (newSettings: Omit<TSettings, 'activeLanguages'>) => void
+- isAnimationEnabled?: boolean
+- isVerticalScrollEnabled?: boolean
+- isMobile?: boolean
+- enableRouting?: boolean
+- allowTickChartTypeOnly?: boolean
+- isConnectionOpened?: boolean
+  - If provided, SmartChart patches/refreshes based on reconnection and granularity
+- shouldFetchTradingTimes?: boolean (default true)
+- shouldFetchTickHistory?: boolean (default true)
+- shouldDrawTicksFromContractInfo?: boolean
+- isLive?: boolean
+- startWithDataFitMode?: boolean
+- enableScroll?: boolean|null
+- enableZoom?: boolean|null
+- zoom?: number
+- yAxisMargin?: { bottom: number; top: number }
+- leftMargin?: number
+- anchorChartToLeft?: boolean
+- margin?: number
+- scrollToEpoch?: number|null
+- startEpoch?: number
+- endEpoch?: number
+- crosshairState?: number|null
+- onCrosshairChange?: (state?: number) => void
+- onGranularityChange?: (granularity?: TGranularity) => void
+- onChartTypeChange?: (chartType?: string) => void
+
+Data injection/preload:
+- initialData?: TInitialChartData
+- chartData?: TInitialChartData
+  - TInitialChartData = { masterData?: TQuote[]; tradingTimes?: TradingTimesResponse['trading_times']; activeSymbols?: ActiveSymbols }
+- networkStatus?: TNetworkConfig ({ class: string; tooltip: string })
+
+Contracts & overlays:
+- contracts_array?: any[] (markers)
+- contractInfo?: ProposalOpenContract
+- allTicks?: keyof AuditDetailsForExpiredContract | []
+- barriers?: TBarrierUpdateProps[]
+  - Has visual config and onChange({ high?, low? })
+
+Callbacks and helpers:
+- onMessage?: (message: TNotification) => void
+- clearChart?: () => void
+- refreshActiveSymbols?: ChartState['refreshActiveSymbols']
+- chartStatusListener?: ChartState['chartStatusListener']
+
+Widgets and composition:
+- topWidgets?: () => React.ReactElement (default renders ChartTitle)
+- bottomWidgets?: () => React.ReactElement
+- toolbarWidget?: () => React.ReactElement
+- chartControlsWidgets?: (({ isMobile?: boolean }) => React.ReactElement) | null
+- enabledChartFooter?: boolean (default true)
+- enabledNavigationWidget?: boolean (default true)
+- children?: React.ReactNode
+- historical?: boolean (affects height on mobile)
+
+Refs (imperative handle):
+- ref?: React.RefObject<{ hasPredictionIndicators(): void; triggerPopup(arg: () => void): void }>
+
+--------------------------------------------------------------------------------
+
+## 6) Quotes, History, and Pagination
+
+Quote shape used internally (TQuote):
+```ts
+type TQuote = {
+  Date: string;        // epoch or ISO as string
+  Close: number;
+  Open?: number;
+  High?: number;
+  Low?: number;
+  Volume?: number;
+  tick?: TicksStreamResponse['tick'];   // for tick streams
+  ohlc?: OHLCStreamResponse['ohlc'];    // for candle streams
+  DT?: Date;
+  prevClose?: number;
+};
+```
+
+Pagination & loading older history (JS Interop):
+- SmartChart can request more history via window.jsInterop.loadHistory(params)
+- Type: TLoadHistoryParams = { count: number; end: number }
+- Typical host behavior:
+  - Handle loadHistory by calling your requestAPI with a ticks_history request that sets end to the provided epoch, to fetch older data, then pass it back to SmartChart via the normal "history" response flow.
+
+--------------------------------------------------------------------------------
+
+## 7) Concrete Implementation Example (TypeScript)
+
+Below is a practical Deriv WebSocket-style implementation for the required functions, including subscribe/forget handling with subscription ids.
+
+```ts
+type Request = Record<string, unknown>;
+type Response = {
+  msg_type: string;
+  echo_req?: Record<string, unknown>;
+  req_id?: number;
+  subscription?: { id: string };
+} & Record<string, any>;
+
+const ws = new WebSocket('wss://deriv.example/ws');
+let nextReqId = 1;
+
+const pending = new Map<number, { resolve: (resp: Response) => void; reject: (e: any) => void }>();
+const subIdToCallback = new Map<string, (resp: Response) => void>();
+const requestToSubId = new Map<string, string>(); // JSON.stringify(request) -> subscription id
+
+ws.onmessage = (ev) => {
+  const msg: Response = JSON.parse(ev.data);
+
+  // Resolve one-shot requests by req_id
+  if (msg.req_id && pending.has(msg.req_id)) {
+    const { resolve } = pending.get(msg.req_id)!;
+    resolve(msg);
+    pending.delete(msg.req_id);
+  }
+
+  // Dispatch streaming updates by subscription id
+  const subId = msg.subscription?.id;
+  if (subId && subIdToCallback.has(subId)) {
+    subIdToCallback.get(subId)!(msg);
+  }
+};
+
+export const requestAPI = (request: Request): Promise<Response> => {
+  const req_id = nextReqId++;
+  ws.send(JSON.stringify({ ...request, req_id }));
+  return new Promise((resolve, reject) => pending.set(req_id, { resolve, reject }));
+};
+
+export const requestSubscribe = (request: Request, callback: (resp: Response) => void): void => {
+  // Ensure subscribe flag
+  const subRequest = { ...request, subscribe: 1 };
+  ws.send(JSON.stringify(subRequest));
+
+  // Bridge first response to learn subscription id and bind callback
+  const req_id = nextReqId++;
+  ws.send(JSON.stringify({ ping: 1, req_id })); // dummy to allocate a req_id if needed; optional pattern
+
+  // In practice, you will receive a first stream message containing subscription.id:
+  // When that message arrives, bind subId -> callback and store request -> subId mapping.
+  // If your backend emits subscription.id on the first data message, handle that in ws.onmessage.
+  // Example binding logic (pseudo):
+  // on first message for this request:
+  //   const id = message.subscription.id;
+  //   subIdToCallback.set(id, callback);
+  //   requestToSubId.set(JSON.stringify(subRequest), id);
+};
+
+export const requestForget = (request: Request, _callback: (resp: Response) => void): void => {
+  // If you can derive subId from the request, prefer id-based forget:
+  const key = JSON.stringify({ ...request, subscribe: 1 });
+  const subId = requestToSubId.get(key);
+  if (subId) {
+    requestForgetStream(subId);
+    requestToSubId.delete(key);
+    subIdToCallback.delete(subId);
+    return;
+  }
+
+  // Fallback: if your transport supports sending a "forget" with the original request/callback shape, do it here.
+  // Otherwise ensure your requestSubscribe stored enough info to forget reliably.
+};
+
+export const requestForgetStream = (subscription_id: string): void => {
+  ws.send(JSON.stringify({ forget: subscription_id }));
+};
+```
+
+Notes:
+- The exact mechanics of capturing the first stream message to learn subscription.id depend on your backend and message routing logic. The important part: bind subscription.id -> callback so you can forget by id later.
+
+--------------------------------------------------------------------------------
+
+## 8) End-to-end Integration Sequence
+
+Initial render:
+1) Include CSS and chunks, set the public path:
+   - import { setSmartChartsPublicPath } from '@deriv-com/derivatives-charts'
+   - setSmartChartsPublicPath('/dist/')
+   - Ensure /dist/smartcharts.css and *.smartcharts.* are deployed and accessible
+
+2) Provide required functions and minimal props:
+```tsx
+<SmartChart
+  requestAPI={requestAPI}
+  requestSubscribe={requestSubscribe}
+  requestForget={requestForget}
+  requestForgetStream={requestForgetStream} // optional
+  id="main-chart"
+  symbol="R_100"
+  granularity={0}
+/>
+```
+
+3) SmartChart mounts:
+   - Initializes context
+   - Chart mounts, chartAdapter connects to DOM
+   - updateProps pushes props into store
+
+4) Data requests made through your functions:
+   - active_symbols (optional; or preload via initialData)
+   - trading_times (optional; or preload via initialData)
+   - ticks_history (one-shot and/or subscribe) for symbol/granularity
+
+5) User changes symbol or granularity:
+   - SmartChart will:
+     - requestForget/requestForgetStream old streams
+     - issue new history and subscribe requests for the new state
+
+6) Unmount:
+   - destroy() tears down state
+   - Adapter unmounted
+   - All streams are forgotten via your functions
+
+--------------------------------------------------------------------------------
+
+## 9) DOM and CSS Structure (Essentials)
+
+Containers/classes:
+- Root: .smartcharts.smartcharts-{theme}
+- Mode: .smartcharts-mobile or .smartcharts-desktop
+- Responsive: .smartcharts-{containerWidth} (on desktop)
+- Modal root: #smartcharts_modal (portals)
+
+Always include smartcharts.css on the page.
+
+--------------------------------------------------------------------------------
+
+## 10) Troubleshooting and Best Practices
+
+- Missing chunks (*.smartcharts.* 404):
+  - Call setSmartChartsPublicPath('/dist/') to match deployed path
+  - Copy chunks from node_modules package to your public dist
+
+- No styles / broken layout:
+  - Ensure smartcharts.css is included
+
+- Double or dangling subscriptions:
+  - Key your subscriptions by (request+callback) or by derived subscription id
+  - Implement requestForgetStream if possible
+
+- Reconnect behavior:
+  - Provide isConnectionOpened so SmartChart can patch/refresh appropriately
+
+- Preloading:
+  - Use initialData/chartData to cut round trips for activeSymbols/tradingTimes/masterData
+
+--------------------------------------------------------------------------------
+
+## 11) Reference Types (Selected)
+
+From src/types/props.types.ts (see file for full declarations):
+
+- TRequestAPI, TRequestSubscribe, TRequestForget, TRequestForgetStream
+- TBinaryAPIRequest, TBinaryAPIResponse
+- TQuote
+- TInitialChartData
+- TSettings
+- TBarrierUpdateProps, TBarrierChangeParam
+- TLoadHistoryParams
+- TNetworkConfig
+- TNotification
+
+BinaryAPI helper: src/binaryapi/BinaryAPI.ts
+- Provides createTickHistoryRequest, getActiveSymbols, getTradingTimes, subscribeTickHistory, forget, forgetStream
+- Uses a key of "symbol-granularity" to group streams
+
+--------------------------------------------------------------------------------
+
+This guide is designed to map 1:1 with the codebase responsibilities and expected contracts, so you can integrate SmartChart deterministically and debug issues quickly.
+
+<!-- [/AI] -->

--- a/docs/migration-derivatives-charts-to-smartchart-champion.md
+++ b/docs/migration-derivatives-charts-to-smartchart-champion.md
@@ -1,0 +1,640 @@
+<!-- [AI] -->
+# Migration Plan: @deriv-com/derivatives-charts ➜ smartchart-champion (per docs/SmartChart.md)
+
+Purpose
+- This document details the end-to-end migration from the legacy derivatives-charts integration to the SmartChart “champion” API described in docs/SmartChart.md.
+- It enumerates all required changes across dependencies, assets, types, functions, props, and implementation details, including concrete adapter code to wire your existing Deriv WS to the new SmartChart contracts.
+
+Assumptions
+- Target npm package name: @deriv-com/smartcharts-champion
+- The champion API requires:
+  - getQuotes (history), subscribeQuotes (live, returns an unsubscribe function), unsubscribeQuotes (explicit server forget)
+  - chartData: { activeSymbols, tradingTimes } supplied by the host
+  - TQuote/TGetQuotesRequest/TGetQuotesResult types (or equivalents provided by package types)
+
+--------------------------------------------------------------------------------
+
+1) Dependencies and Imports
+
+1.1 package.json
+- Remove or stop using:
+  - @deriv-com/derivatives-charts
+- Add:
+  - @deriv-com/smartcharts-champion
+- Example:
+```json
+{
+  "dependencies": {
+    "@deriv-com/smartcharts-champion": "^X.Y.Z"
+  }
+}
+```
+
+1.2 Imports in code
+- Replace:
+  - import { SmartChart, ChartTitle } from '@deriv-com/derivatives-charts';
+  - import '@deriv-com/derivatives-charts/dist/smartcharts.css';
+- With:
+  - import { SmartChart, ChartTitle, ToolbarWidget, ChartMode, StudyLegend, Views, DrawTools, Share } from '@deriv-com/smartcharts-champion';
+  - import '@deriv-com/smartcharts-champion/dist/smartcharts.css'; // if the champion package ships CSS similarly
+
+Note:
+- If the champion package uses a different public path initializer than setSmartChartsPublicPath, update accordingly. If no public path API is required, remove the call.
+
+--------------------------------------------------------------------------------
+
+2) Assets and Public Path
+
+2.1 Remove derivative-specific copying rules
+- In rsbuild.config.ts, remove copy rules referencing node_modules/@deriv-com/derivatives-charts/*
+
+2.2 Add champion assets if required
+- If @deriv-com/smartcharts-champion provides dist assets, copy them similarly into /js/smartcharts/ (or a new path):
+```ts
+output: {
+  copy: [
+    { from: 'node_modules/@deriv-com/smartcharts-champion/dist/*', to: 'js/smartcharts/[name][ext]' },
+    { from: 'node_modules/@deriv-com/smartcharts-champion/dist/chart/assets/*', to: 'assets/[name][ext]' },
+    { from: 'node_modules/@deriv-com/smartcharts-champion/dist/chart/assets/fonts/*', to: 'assets/fonts/[name][ext]' },
+    { from: 'node_modules/@deriv-com/smartcharts-champion/dist/chart/assets/shaders/*', to: 'assets/shaders/[name][ext]' },
+    { from: path.join(__dirname, 'public') },
+  ],
+}
+```
+
+2.3 Public path initialization
+- If applicable, replace:
+  - setSmartChartsPublicPath(getUrlBase('/js/smartcharts/'));
+- With champion’s equivalent, or remove if not needed by @deriv-com/smartcharts-champion.
+
+--------------------------------------------------------------------------------
+
+3) Types: Add or Align to Champion Contracts
+
+Create a local adapter types file if the package types are not available or you need an internal bridge.
+
+3.1 New SmartChart types (minimal)
+```ts
+// src/types/smartchart.types.ts
+// [AI]
+export type TGranularity =
+  | 0
+  | 60
+  | 120
+  | 180
+  | 300
+  | 600
+  | 900
+  | 1800
+  | 3600
+  | 7200
+  | 14400
+  | 28800
+  | 86400;
+
+export type TQuote = {
+  Date: string;       // ISO string or epoch string
+  Close: number;
+  Open?: number;
+  High?: number;
+  Low?: number;
+  Volume?: number;
+  tick?: { epoch: number; quote: number; symbol?: string; id?: string };
+  ohlc?: { open: number; high: number; low: number; close: number; open_time: number };
+  DT?: Date;
+  prevClose?: number;
+};
+
+export type TGetQuotesRequest = {
+  symbol: string;
+  granularity: TGranularity;
+  count: number;
+  start?: number;
+  end?: number;
+  style?: 'candles' | 'ticks';
+};
+
+export type TGetQuotesResult = {
+  candles?: Array<{ open: number; high: number; low: number; close: number; epoch: number }>;
+  history?: { prices: number[]; times: number[] }; // ticks
+};
+
+export type ActiveSymbol = {
+  display_name: string;
+  market: string;
+  market_display_name: string;
+  subgroup: string;
+  subgroup_display_name: string;
+  submarket: string;
+  submarket_display_name: string;
+  symbol: string;
+  symbol_type: string;
+  pip: number;
+  exchange_is_open: 0 | 1;
+  is_trading_suspended: 0 | 1;
+  delay_amount?: number;
+};
+export type ActiveSymbols = ActiveSymbol[];
+
+export type TradingTimesMap = Record<
+  string,
+  {
+    isOpen: boolean;
+    openTime: string;
+    closeTime: string;
+  }
+>;
+// [/AI]
+```
+
+3.2 Remove derivatives-charts shim if no longer used
+- src/types/derivatives-charts.d.ts can be deleted after migration (or kept until fully removed from code paths).
+
+--------------------------------------------------------------------------------
+
+4) Network Provider Adapters
+
+Replace derivatives-charts requestAPI/requestSubscribe/requestForget* with champion’s:
+- getQuotes (one-shot history)
+- subscribeQuotes (live; returns a function to unsubscribe)
+- unsubscribeQuotes (explicit server forget, optional but recommended)
+
+4.1 History adapter (getQuotes)
+```ts
+// src/pages/chart/providers.ts
+// [AI]
+import chart_api from '@/external/bot-skeleton/services/api/chart-api';
+import type { TGetQuotesRequest, TGetQuotesResult } from '@/types/smartchart.types';
+import type { TicksHistoryRequest } from '@deriv/api-types';
+
+export const getQuotes = async ({
+  symbol,
+  granularity,
+  count,
+  start,
+  end,
+  style,
+}: TGetQuotesRequest): Promise<TGetQuotesResult> => {
+  // Deriv WS: ticks_history one-shot
+  const is_ticks = !granularity || granularity === 0;
+  const req: TicksHistoryRequest = {
+    ticks_history: symbol,
+    end: end ? String(end) : 'latest',
+    adjust_start_time: 1,
+    ...(start ? { start: String(start) } : {}),
+    ...(is_ticks
+      ? { style: 'ticks', count: String(count) }
+      : { style: 'candles', granularity, count: String(count) }),
+  };
+
+  const resp: any = await chart_api.api.send(req);
+
+  if (is_ticks) {
+    // resp.history: { prices: number[], times: number[] }
+    const history = resp?.history || resp?.ticks_history || {};
+    return {
+      history: {
+        prices: history.prices || [],
+        times: history.times || [],
+      },
+    };
+  }
+
+  // Candles: resp.candles: Array<{ open, high, low, close, epoch }>
+  const candles = (resp?.candles || []).map((c: any) => ({
+    open: Number(c.open),
+    high: Number(c.high),
+    low: Number(c.low),
+    close: Number(c.close),
+    epoch: Number(c.epoch || c.open_time),
+  }));
+  return { candles };
+};
+// [/AI]
+```
+
+4.2 Streaming adapter (subscribeQuotes)
+```ts
+// src/pages/chart/providers.ts (continued)
+// [AI]
+import type { TQuote, TGranularity } from '@/types/smartchart.types';
+import type { TicksStreamRequest } from '@deriv/api-types';
+
+const rxSubscriptions: Record<string, { unsubscribe?: () => void } | undefined> = {};
+let lastSubscriptionId: string | null = null;
+
+export const subscribeQuotes = (
+  params: { symbol: string; granularity: TGranularity },
+  onQuote: (q: TQuote) => void
+) => {
+  const { symbol, granularity } = params;
+  const is_ticks = !granularity || granularity === 0;
+
+  // Build subscribe request
+  const req: TicksStreamRequest = is_ticks
+    ? { ticks: symbol, subscribe: 1 }
+    : { ticks_history: symbol, style: 'candles', granularity, subscribe: 1 } as any;
+
+  let currentId: string | null = null;
+  let rxSub: { unsubscribe?: () => void } | undefined;
+
+  // Start stream: the first message should contain subscription.id
+  chart_api.api
+    .send(req)
+    .then((first: any) => {
+      currentId = first?.subscription?.id || null;
+      lastSubscriptionId = currentId;
+
+      // Emit first message as TQuote (if present)
+      const data = first;
+      const q = toTQuoteFromStream(data, granularity);
+      if (q) onQuote(q);
+
+      // Subscribe to subsequent messages and filter by subscription id
+      rxSub = chart_api.api
+        .onMessage()
+        ?.subscribe(({ data: msg }: { data: any }) => {
+          if (msg?.subscription?.id === currentId) {
+            const quote = toTQuoteFromStream(msg, granularity);
+            if (quote) onQuote(quote);
+          }
+        });
+
+      if (currentId) rxSubscriptions[currentId] = rxSub;
+    })
+    .catch(() => {
+      // No-op; caller can decide how to handle connection errors
+    });
+
+  // Return unsubscribe function
+  return () => {
+    if (currentId) {
+      rxSubscriptions[currentId]?.unsubscribe?.();
+      delete rxSubscriptions[currentId];
+      chart_api.api.forget(currentId);
+    }
+  };
+};
+
+const toTQuoteFromStream = (msg: any, granularity: TGranularity): TQuote | null => {
+  const is_ticks = !granularity || granularity === 0;
+
+  if (is_ticks && msg?.tick) {
+    const { epoch, quote } = msg.tick;
+    return {
+      Date: String(epoch),
+      Close: Number(quote),
+      tick: msg.tick,
+    };
+  }
+
+  if (!is_ticks && msg?.ohlc) {
+    const { open, high, low, close, open_time } = msg.ohlc;
+    return {
+      Date: String(open_time),
+      Open: Number(open),
+      High: Number(high),
+      Low: Number(low),
+      Close: Number(close),
+      ohlc: msg.ohlc,
+    };
+  }
+
+  return null;
+};
+// [/AI]
+```
+
+4.3 Explicit server forget (unsubscribeQuotes)
+```ts
+// src/pages/chart/providers.ts (continued)
+// [AI]
+import type { TGetQuotesRequest } from '@/types/smartchart.types';
+
+// Optional helper: If you track symbol+granularity ➜ subscription id mapping,
+// you can forget by derived id here. For now, this is a no-op wrapper since
+// subscribeQuotes returns an unsubscribe function that already forgets by id.
+export const unsubscribeQuotes = (_request?: TGetQuotesRequest, _cb?: (data: any) => void) => {
+  // Intentionally left generic. Prefer to rely on the unsubscribe() function
+  // returned from subscribeQuotes, which calls api.forget(currentId).
+};
+// [/AI]
+```
+
+--------------------------------------------------------------------------------
+
+5) chartData: Provide activeSymbols and tradingTimes
+
+Champion expects the host to pass both lists, rather than auto-fetch internally.
+
+5.1 Build chartData in your Chart page
+```ts
+// src/pages/chart/chart.tsx (new champion wiring highlights)
+// [AI]
+import { SmartChart, ChartTitle, ToolbarWidget, ChartMode, StudyLegend, Views, DrawTools, Share } from '@deriv-com/smartcharts-champion';
+import '@deriv-com/smartcharts-champion/dist/smartcharts.css';
+import { getQuotes, subscribeQuotes, unsubscribeQuotes } from './providers';
+import type { ActiveSymbols, TradingTimesMap } from '@/types/smartchart.types';
+import { ApiHelpers } from '@/external/bot-skeleton';
+// You likely already have a TradingTimes service; create a tiny adapter to TradingTimesMap.
+
+const toTradingTimesMap = (source: any): TradingTimesMap => {
+  // Source from your existing trading-times.js service
+  const map: TradingTimesMap = {};
+  Object.keys(source || {}).forEach(symbol => {
+    const info = source[symbol];
+    map[symbol] = {
+      isOpen: !!info?.is_opened,
+      openTime: String(info?.times?.open_time || ''),
+      closeTime: String(info?.times?.close_time || ''),
+    };
+  });
+  return map;
+};
+
+const Chart = observer(({ show_digits_stats }: { show_digits_stats: boolean }) => {
+  // Existing stores, settings, etc...
+
+  // Acquire active symbols and trading times from existing helpers/services
+  const activeSymbols: ActiveSymbols =
+    (ApiHelpers?.instance?.active_symbols?.active_symbols as any[]) ||
+    (ApiHelpers?.instance?.active_symbols as any)?.active_symbols ||
+    [];
+
+  // Suppose you have a trading_times service instance or cache
+  // Pass a compatible record down here (adapt from current trading-times.js data)
+  const tradingTimesRaw = /* retrieve from your trading-times service/cache */;
+  const tradingTimes = toTradingTimesMap(tradingTimesRaw);
+
+  const chartData = { activeSymbols, tradingTimes };
+
+  return (
+    <SmartChart
+      id="dbot"
+      symbol={symbol}
+      chartType={chart_type}
+      granularity={granularity}
+      isMobile={isMobile}
+      settings={settings}
+      // Champion data providers:
+      getQuotes={getQuotes}
+      subscribeQuotes={subscribeQuotes}
+      unsubscribeQuotes={unsubscribeQuotes}
+      // Preloaded data:
+      chartData={chartData}
+      topWidgets={() => <ChartTitle onChange={onSymbolChange} />}
+      toolbarWidget={() => (
+        <ToolbarWidget>
+          <ChartMode />
+          <StudyLegend />
+          <Views />
+          <DrawTools />
+          <Share />
+        </ToolbarWidget>
+      )}
+      enabledNavigationWidget={isDesktop}
+      enabledChartFooter={false}
+      isLive
+      leftMargin={80}
+    />
+  );
+});
+// [/AI]
+```
+
+5.2 Remove derivatives-charts props
+- Delete requestAPI, requestSubscribe, requestForget, requestForgetStream from your SmartChart invocation.
+
+--------------------------------------------------------------------------------
+
+6) Remove Derivatives-specific Lifecycle Code
+
+6.1 Component unmount cleanup
+- You no longer need to call forgetAll('ticks') if all streams are managed by returning unsubscribe from subscribeQuotes.
+- Ensure your subscribeQuotes cleanup unsubscribes Rx listeners and sends api.forget(subscription_id).
+
+6.2 isConnectionOpened
+- Champion does not rely on isConnectionOpened prop (based on docs/SmartChart.md). Remove it unless the package specifies otherwise.
+
+--------------------------------------------------------------------------------
+
+7) Toolbar/Widgets Compatibility
+
+- If you used derivatives-charts ToolbarWidget/Views/DrawTools/etc, import them from the champion package if provided:
+  - From docs/SmartChart.md, public exports include ChartMode, StudyLegend, Views, DrawTools, Share, ToolbarWidget.
+- If any component names differ, adjust accordingly.
+
+--------------------------------------------------------------------------------
+
+8) Markers and contracts_array
+
+- The champion doc keeps contracts_array behavior. Continue passing your contracts overlay if used.
+- Ensure each marker epoch is in seconds; omit quote to allow interpolation.
+
+--------------------------------------------------------------------------------
+
+9) Testing and Verification
+
+- Start app and verify:
+  - CSS loads for @deriv-com/smartcharts-champion (or your champion name).
+  - Active symbols/trading times are provided via chartData (symbol menu works, open/close status correct).
+  - History loads for both ticks (granularity 0) and candles (>0).
+  - Live streaming works; switching symbol/timeframe resubscribes cleanly with no console noise.
+  - Pagination: Scroll left should trigger jsInterop.loadHistory path if provided by the champion package (validate integration need).
+  - Unmount and navigation do not leak subscriptions (confirm no onMessage events after unmount).
+
+--------------------------------------------------------------------------------
+
+10) Diff Checklist (Concrete To-Do)
+
+- Dependencies
+  - Remove @deriv-com/derivatives-charts
+  - Add @deriv-com/smartcharts-champion
+
+- Imports and CSS
+  - Update SmartChart, widgets imports to new module
+  - Update CSS import to @deriv-com/smartcharts-champion/dist/smartcharts.css
+
+- Assets and public path
+  - Update rsbuild.config.ts copy rules to champion’s dist/assets
+  - Remove setSmartChartsPublicPath unless champion requires a similar call
+
+- Types
+  - Add src/types/smartchart.types.ts (TQuote, TGetQuotesRequest, TGetQuotesResult, ActiveSymbols, TradingTimesMap)
+  - Remove derivatives-charts d.ts shim if unused
+
+- Providers
+  - Add src/pages/chart/providers.ts with getQuotes, subscribeQuotes, unsubscribeQuotes
+  - Ensure subscribeQuotes returns an unsubscribe function and calls api.forget(id)
+
+- Chart page
+  - Replace SmartChart props: remove requestAPI/requestSubscribe/requestForget*
+  - Add getQuotes/subscribeQuotes/unsubscribeQuotes and chartData
+  - Adapt toolbarWidget and topWidgets to champion exports
+
+- Trading times map
+  - Create an adapter from your trading-times.js structure to TradingTimesMap (isOpen/openTime/closeTime)
+
+- Cleanup
+  - Remove explicit forgetAll('ticks') if redundant
+  - Ensure unsubscribe closures fully release Rx subscriptions
+
+--------------------------------------------------------------------------------
+
+Appendix A: Full providers.ts (combined)
+
+// src/pages/chart/providers.ts
+// [AI]
+import chart_api from '@/external/bot-skeleton/services/api/chart-api';
+import type { TicksHistoryRequest, TicksStreamRequest } from '@deriv/api-types';
+import type {
+  TGetQuotesRequest,
+  TGetQuotesResult,
+  TQuote,
+  TGranularity,
+} from '@/types/smartchart.types';
+
+const rxSubscriptions: Record<string, { unsubscribe?: () => void } | undefined> = {};
+
+export const getQuotes = async ({
+  symbol,
+  granularity,
+  count,
+  start,
+  end,
+  style,
+}: TGetQuotesRequest): Promise<TGetQuotesResult> => {
+  const is_ticks = !granularity || granularity === 0;
+  const req: TicksHistoryRequest = {
+    ticks_history: symbol,
+    end: end ? String(end) : 'latest',
+    adjust_start_time: 1,
+    ...(start ? { start: String(start) } : {}),
+    ...(is_ticks
+      ? { style: 'ticks', count: String(count) }
+      : { style: 'candles', granularity, count: String(count) }),
+  };
+
+  const resp: any = await chart_api.api.send(req);
+
+  if (is_ticks) {
+    const history = resp?.history || resp?.ticks_history || {};
+    return {
+      history: {
+        prices: history.prices || [],
+        times: history.times || [],
+      },
+    };
+  }
+
+  const candles = (resp?.candles || []).map((c: any) => ({
+    open: Number(c.open),
+    high: Number(c.high),
+    low: Number(c.low),
+    close: Number(c.close),
+    epoch: Number(c.epoch || c.open_time),
+  }));
+  return { candles };
+};
+
+export const subscribeQuotes = (
+  params: { symbol: string; granularity: TGranularity },
+  onQuote: (q: TQuote) => void
+) => {
+  const { symbol, granularity } = params;
+  const is_ticks = !granularity || granularity === 0;
+
+  const req: TicksStreamRequest = is_ticks
+    ? { ticks: symbol, subscribe: 1 }
+    : { ticks_history: symbol, style: 'candles', granularity, subscribe: 1 } as any;
+
+  let currentId: string | null = null;
+  let rxSub: { unsubscribe?: () => void } | undefined;
+
+  chart_api.api
+    .send(req)
+    .then((first: any) => {
+      currentId = first?.subscription?.id || null;
+
+      const firstQuote = toTQuoteFromStream(first, granularity);
+      if (firstQuote) onQuote(firstQuote);
+
+      rxSub = chart_api.api.onMessage()?.subscribe(({ data: msg }: { data: any }) => {
+        if (msg?.subscription?.id === currentId) {
+          const q = toTQuoteFromStream(msg, granularity);
+          if (q) onQuote(q);
+        }
+      });
+
+      if (currentId) rxSubscriptions[currentId] = rxSub;
+    })
+    .catch(() => { /* noop */ });
+
+  return () => {
+    if (currentId) {
+      rxSubscriptions[currentId]?.unsubscribe?.();
+      delete rxSubscriptions[currentId];
+      chart_api.api.forget(currentId);
+    }
+  };
+};
+
+export const unsubscribeQuotes = (_request?: TGetQuotesRequest) => {
+  // Optional global forget; prefer per-subscription unsubscribe returned by subscribeQuotes
+};
+
+const toTQuoteFromStream = (msg: any, granularity: TGranularity): TQuote | null => {
+  const is_ticks = !granularity || granularity === 0;
+
+  if (is_ticks && msg?.tick) {
+    const { epoch, quote } = msg.tick;
+    return {
+      Date: String(epoch),
+      Close: Number(quote),
+      tick: msg.tick,
+    };
+  }
+
+  if (!is_ticks && msg?.ohlc) {
+    const { open, high, low, close, open_time } = msg.ohlc;
+    return {
+      Date: String(open_time),
+      Open: Number(open),
+      High: Number(high),
+      Low: Number(low),
+      Close: Number(close),
+      ohlc: msg.ohlc,
+    };
+  }
+  return null;
+};
+// [/AI]
+
+--------------------------------------------------------------------------------
+
+Appendix B: Chart page diff (high level)
+
+- Before (derivatives-charts):
+  - Props: requestAPI, requestSubscribe, requestForget, requestForgetStream, isConnectionOpened
+  - CSS: @deriv-com/derivatives-charts/dist/smartcharts.css
+  - Public path: setSmartChartsPublicPath
+
+- After (champion):
+  - Props: getQuotes, subscribeQuotes, unsubscribeQuotes, chartData
+  - CSS: @deriv-com/smartcharts-champion/dist/smartcharts.css
+  - Public path: remove or champion-equivalent
+  - Widgets: import from @deriv-com/smartcharts-champion
+
+--------------------------------------------------------------------------------
+
+Deliverable
+
+After completing the checklist above:
+- The app no longer references @deriv-com/derivatives-charts.
+- SmartChart is sourced from @deriv-com/smartcharts-champion.
+- Data providers implement champion contracts and are backed by your Deriv WS transport.
+- ActiveSymbols and TradingTimes are provided via chartData.
+- Streams are isolated by subscription id and cleaned up using the returned unsubscribe function.
+
+This plan ensures parity with docs/SmartChart.md and positions the integration for future enhancements with the champion SmartChart API.
+<!-- [/AI] -->

--- a/docs/smartchart-implementation-audit.md
+++ b/docs/smartchart-implementation-audit.md
@@ -1,0 +1,342 @@
+<!-- [AI] -->
+# SmartChart Implementation Audit vs docs/derivative-chart.md
+
+Scope
+- Goal: Verify current integration of @deriv-com/derivatives-charts SmartChart in this repo matches the contracts and workflow prescribed by docs/derivative-chart.md.
+- Key areas:
+  - Required network functions (requestAPI/requestSubscribe/requestForget/requestForgetStream)
+  - Request/response shapes and streaming behavior
+  - Lifecycle and cleanup
+  - Assets and public path
+  - Type contract and version alignment
+
+Summary Verdict
+- Status: Partially compliant
+- Strong matches:
+  - SmartChart usage is present with correct CSS import and asset public path.
+  - requestAPI and requestSubscribe are implemented and passed to SmartChart.
+- Conflicts to address (highest impact first):
+  1) requestForget and requestForgetStream passed as no-ops (prevents library-driven unsubscription).
+  2) requestSubscribe forwards all websocket messages (no filtering by subscription id).
+  3) Local type declarations for SmartChart contracts diverge from docs (can hide runtime contract mismatches).
+  4) isConnectionOpened is evaluated only as “instance exists”, not actual WS open state.
+  5) Cleanup uses forgetAll('ticks') but does not unsubscribe local Rx subscriptions per stream id (risk of dangling listeners).
+
+If these are fixed, the integration will align closely with the documented behavior.
+
+--------------------------------------------------------------------------------
+
+Evidence Mapping
+
+1) Where SmartChart is used
+- File: src/pages/chart/chart.tsx
+
+Key excerpt (abbreviated):
+```tsx
+import { ChartTitle, SmartChart } from '@deriv-com/derivatives-charts';
+import '@deriv-com/derivatives-charts/dist/smartcharts.css';
+
+const requestAPI = (req: ServerTimeRequest | ActiveSymbolsRequest | TradingTimesRequest) => {
+  return chart_api.api.send(req);
+};
+const requestForgetStream = (subscription_id: string) => {
+  subscription_id && chart_api.api.forget(subscription_id);
+};
+
+const requestSubscribe = async (req: TicksStreamRequest, callback: (data: any) => void) => {
+  try {
+    requestForgetStream(chartSubscriptionIdRef.current);
+    const history = await chart_api.api.send(req);
+    setChartSubscriptionId(history?.subscription.id);
+    if (history) callback(history);
+    if (req.subscribe === 1) {
+      subscriptions[history?.subscription.id] =
+        chart_api.api.onMessage()?.subscribe(({ data }: { data: TicksHistoryResponse }) => {
+          callback(data);
+        });
+    }
+  } catch (e) { /* ... */ }
+};
+
+<SmartChart
+  id='dbot'
+  /* ... */
+  requestAPI={requestAPI}
+  requestForget={() => {}}
+  requestForgetStream={() => {}}
+  requestSubscribe={requestSubscribe}
+  /* ... */
+/>
+```
+
+Observations:
+- requestAPI implemented correctly (forwards opaque request object).
+- requestSubscribe present, sets a subscription id and hooks a global onMessage() stream.
+- requestForget and requestForgetStream are passed as no-ops despite working requestForgetStream being defined locally (not passed).
+- A component-level unmount cleanup calls chart_api.api.forgetAll('ticks') (via useEffect cleanup).
+
+2) Assets and public path
+- File: src/app/app-content.jsx
+```tsx
+import { setSmartChartsPublicPath } from '@deriv-com/derivatives-charts';
+/* ... */
+React.useEffect(() => {
+  setSmartChartsPublicPath(getUrlBase('/js/smartcharts/'));
+}, []);
+```
+
+- File: rsbuild.config.ts
+```ts
+output: {
+  copy: [
+    { from: 'node_modules/@deriv-com/derivatives-charts/dist/*', to: 'js/smartcharts/[name][ext]' },
+    { from: 'node_modules/@deriv-com/derivatives-charts/dist/chart/assets/*', to: 'assets/[name][ext]' },
+    { from: 'node_modules/@deriv-com/derivatives-charts/dist/chart/assets/fonts/*', to: 'assets/fonts/[name][ext]' },
+    { from: 'node_modules/@deriv-com/derivatives-charts/dist/chart/assets/shaders/*', to: 'assets/shaders/[name][ext]' },
+    { from: path.join(__dirname, 'public') },
+  ],
+},
+```
+
+Observations:
+- Matches the doc: CSS is imported and chunks are on /js/smartcharts/, with setSmartChartsPublicPath pointing there.
+- Required assets (fonts, shaders) are correctly copied.
+
+3) Local Type Declarations (shim)
+- File: src/types/derivatives-charts.d.ts
+```ts
+export interface SmartChartProps {
+  /* ... */
+  requestAPI?: (req: any) => Promise<any>;
+  requestForget?: () => void;
+  requestForgetStream?: () => void;
+  requestSubscribe?: (req: any, callback: (data: any) => void) => Promise<void>;
+  /* ... */
+}
+```
+
+Observations:
+- Diverges from the doc (which specifies requestForget(req, cb), requestForgetStream(id: string), requestSubscribe returns void).
+- This can mask contract mismatches at compile-time.
+
+4) Package Version Alignment
+- package.json: "@deriv-com/derivatives-charts": "^1.1.3"
+- package-lock.json resolved: 1.1.4
+
+Observations:
+- A newer version is installed than declared. Not a direct issue but relevant when aligning contracts; ensure docs reflect the package’s runtime behavior.
+
+--------------------------------------------------------------------------------
+
+Conflicts vs docs/derivative-chart.md
+
+1) requestForget and requestForgetStream not wired
+- Doc Requires:
+  - requestForget: (request, callback) => void
+  - requestForgetStream?: (id: string) => void
+- Current Code:
+  - Passes requestForget={() => {}} and requestForgetStream={() => {}} to SmartChart.
+  - A working requestForgetStream is defined locally but not passed.
+- Impact:
+  - SmartChart cannot explicitly instruct the host to forget the old streams on symbol/granularity changes or during its own destroy() lifecycle.
+  - Current workaround:
+    - requestSubscribe() proactively forgets the last stream id.
+    - Unmount cleanup calls forgetAll('ticks').
+  - Risks:
+    - Dangling subscriptions if library invokes requestForget/requestForgetStream which are no-ops.
+    - Possible unintended messages received by the chart after symbol/timeframe changes.
+
+2) requestSubscribe message dispatch is not filtered by subscription.id
+- Doc Guidance:
+  - Keep association of request ↔ callback OR subscription id ↔ callback.
+  - Dispatch only the stream updates for that subscription id to the supplied callback.
+- Current Code:
+  - Subscribes to chart_api.api.onMessage() globally and forwards every incoming data event to the SmartChart callback.
+- Impact:
+  - The chart callback may receive unrelated messages (e.g., proposal, balance, open contract, other subscriptions), violating the “per-stream” isolation.
+  - Increased risk of race conditions, wrong symbol updates, or chart glitches on multi-source traffic.
+
+3) Type contract divergence in local declarations
+- Doc Contracts:
+  - requestSubscribe returns void.
+  - requestForget(request, cb) and requestForgetStream(id: string) exist.
+- Current Type Shim:
+  - requestSubscribe returns Promise<void>;
+  - requestForget: () => void and requestForgetStream: () => void (no parameters).
+- Impact:
+  - Type signatures no longer help catch incorrect wiring.
+  - At runtime, SmartChart may invoke with arguments; the provided functions ignore them.
+
+4) isConnectionOpened semantics
+- Doc:
+  - isConnectionOpened guides reconnection patch behaviors.
+- Current Code:
+  - const is_connection_opened = !!chart_api?.api;
+- Impact:
+  - A truthy api instance doesn’t guarantee WS connection is open (readyState === 1).
+  - SmartChart may misinterpret connection state and skip/trigger patches incorrectly.
+
+5) Cleanup robustness
+- Current Cleanup:
+  - On component unmount: chart_api.api.forgetAll('ticks').
+  - No explicit unsubscribe on the Rx subscription stored under subscriptions[subscription.id].
+- Impact:
+  - Rx subscription may continue listening until GC or WS close, even after server-side forget. Proper unsubscribe reduces memory and event noise.
+
+--------------------------------------------------------------------------------
+
+Request/Response Shapes Alignment
+
+- requestAPI(req)
+  - Forwards opaque Deriv-style requests (active_symbols, trading_times, time, ticks_history).
+  - Aligns with doc’s “SmartChart forwards request objects as-is”.
+- requestSubscribe(req, callback)
+  - Sends req; if subscribe is on, library likely expects streaming “tick/ohlc” messages in the same shape as doc examples (msg_type, tick/ohlc, subscription.id).
+  - Current code relays the first response (history) and then forwards every subsequent onMessage event (unfiltered).
+- Suggested alignment:
+  - Ensure req includes subscribe: 1 when required.
+  - Filter stream messages by subscription.id before invoking callback.
+
+--------------------------------------------------------------------------------
+
+Remediation Plan (Concrete Patches)
+
+1) Pass working forget functions to SmartChart
+- Replace the no-ops with actual implementations.
+
+Before (src/pages/chart/chart.tsx):
+```tsx
+<SmartChart
+  /* ... */
+  requestForget={() => {}}
+  requestForgetStream={() => {}}
+  /* ... */
+/>
+```
+
+After:
+```tsx
+// Keep a local map if you later expand to multi-stream usage:
+const rxSubscriptions: Record<string, { unsubscribe?: () => void } | undefined> = {};
+
+const requestForget = (_req?: any, _cb?: any) => {
+  const id = chartSubscriptionIdRef.current;
+  if (id) {
+    // Unsubscribe local Rx listener first (defensive)
+    rxSubscriptions[id]?.unsubscribe?.();
+    delete rxSubscriptions[id];
+    chart_api.api.forget(id);
+  }
+};
+
+<SmartChart
+  /* ... */
+  requestForget={requestForget}
+  requestForgetStream={requestForgetStream}  // the existing function you already defined
+  /* ... */
+/>
+```
+
+2) Filter onMessage by subscription id (per-stream isolation)
+Before:
+```ts
+subscriptions[history?.subscription.id] =
+  chart_api.api.onMessage()?.subscribe(({ data }) => {
+    callback(data);
+  });
+```
+
+After:
+```ts
+const currentId = history?.subscription?.id;
+if (currentId) {
+  // Unsubscribe any previous Rx listener for the last id
+  const prevId = chartSubscriptionIdRef.current;
+  if (prevId && rxSubscriptions[prevId]) {
+    rxSubscriptions[prevId]?.unsubscribe?.();
+    delete rxSubscriptions[prevId];
+  }
+
+  rxSubscriptions[currentId] = chart_api.api.onMessage()?.subscribe(({ data }: { data: any }) => {
+    if (data?.subscription?.id === currentId) {
+      callback(data);
+    }
+  });
+}
+```
+
+3) Make isConnectionOpened reflect actual socket state
+Before:
+```ts
+const is_connection_opened = !!chart_api?.api;
+```
+
+After:
+```ts
+const is_connection_opened = chart_api?.api?.connection?.readyState === 1;
+```
+
+4) Optional: align local type declarations to doc contracts
+- File: src/types/derivatives-charts.d.ts
+- Update signatures to match docs (and what you intend to pass):
+
+```ts
+export interface SmartChartProps {
+  /* ... */
+  requestAPI?: (req: any) => Promise<any>;
+  requestSubscribe?: (req: any, callback: (data: any) => void) => void; // return void
+  requestForget?: (req: any, callback: (data: any) => void) => void;   // include args
+  requestForgetStream?: (id: string) => void;                           // include id
+  /* ... */
+}
+```
+
+Note: Changing the d.ts is not required for runtime but helps catch mismatches during development. Ensure this matches the actual library prop contracts for the installed version.
+
+5) Ensure robust unmount cleanup
+- In addition to server-side forgetAll('ticks'), also:
+  - Unsubscribe any active Rx subscription stored under rxSubscriptions[currentId].
+  - Clear any local state referencing old ids.
+
+--------------------------------------------------------------------------------
+
+QA Checklist (Post-Fix)
+
+- Subscription lifecycle
+  - On symbol change:
+    - SmartChart calls requestForget/Stream for the old stream → server unsubscribes.
+    - Local Rx subscription is unsubscribed and removed.
+    - New requestSubscribe starts and only the new subscription id events reach the callback.
+
+- Noise isolation
+  - Global onMessage events for other msg_types do not reach the chart callback (verify by logging data.msg_type and data.subscription?.id checks).
+
+- Reconnection behavior
+  - With isConnectionOpened using readyState, SmartChart patches refreshes only when the socket is actually open.
+
+- Assets
+  - CSS and chunks load via /js/smartcharts/ with no 404s.
+
+- Types
+  - Locally updated d.ts matches runtime usage; TypeScript flags if wrong function signatures are passed.
+
+--------------------------------------------------------------------------------
+
+Conclusion
+
+- The current integration is close and functional in basic scenarios but deviates from the documented SmartChart contracts in unsubscription and stream dispatch.
+- Wiring the forget functions properly and filtering stream messages by subscription id will bring it in line with docs/derivative-chart.md and mitigate risks of dangling subscriptions or noisy callbacks.
+- Consider aligning local type definitions and the isConnectionOpened semantics for more accurate behavior and better developer feedback.
+
+Appendix: Key References
+
+- SmartChart usage and network functions: src/pages/chart/chart.tsx
+- Public path and chunk distribution:
+  - src/app/app-content.jsx (setSmartChartsPublicPath)
+  - rsbuild.config.ts (copy assets)
+- Local SmartChart type shim: src/types/derivatives-charts.d.ts
+- Deriv API integration used by chart page: src/external/bot-skeleton/services/api/chart-api.js
+- Package versions:
+  - package.json: "@deriv-com/derivatives-charts": "^1.1.3"
+  - package-lock.json: resolved 1.1.4
+<!-- [/AI] -->


### PR DESCRIPTION
This pull request adds a comprehensive audit document (`docs/smartchart-implementation-audit.md`) comparing the current integration of the `@deriv-com/derivatives-charts` SmartChart with the contracts and workflow prescribed by `docs/derivative-chart.md`. The audit identifies several areas of partial compliance, highlights key integration conflicts, and provides concrete remediation steps to align the implementation with documented expectations.

**Integration conflicts and remediation recommendations:**

*Network function wiring and stream lifecycle:*
- The audit finds that `requestForget` and `requestForgetStream` are currently passed as no-ops to SmartChart, preventing proper unsubscription and cleanup as expected by the library. It recommends passing actual implementations to ensure SmartChart can instruct the host to forget old streams and clean up correctly.
- The current `requestSubscribe` implementation forwards all websocket messages to the callback without filtering by subscription id, risking unrelated data and race conditions. The document suggests filtering messages by subscription id to maintain per-stream isolation.
- Cleanup logic only calls server-side `forgetAll('ticks')` but does not unsubscribe local Rx subscriptions, risking dangling listeners. The audit advises explicitly unsubscribing Rx subscriptions by stream id during cleanup.

*Type contract and version alignment:*
- Local type declarations for SmartChart props diverge from documented contracts, which may hide runtime mismatches. The audit recommends updating